### PR TITLE
Ajout des événements détaillés de planning (endpoint /agenda/event/{eventId})

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# JetBrains suite files
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src
 COPY . .
 ENV CGO_ENABLED=0
 RUN go get -d -v ./...
-RUN go build -a -installsuffix cgo -o isen-api .
+RUN go build -a -installsuffix cgo -o isen-api -tags timetzdata .
 
 FROM scratch AS runtime
 ENV GIN_MODE=release

--- a/openapi.yml
+++ b/openapi.yml
@@ -138,6 +138,49 @@ paths:
                   ClassName: "CM"
         '401':
           description: Not authenticated
+  /agenda/event/{eventId}:
+    summary: Returns an event's details from the user's personal agenda
+    description: TODO
+    get:
+      security:
+        - BearerAuth: [ ]
+      parameters:
+        - in: path
+          name: eventId
+          schema:
+            type: integer
+            minimum: 1
+          description: The event ID that can be found in the agenda.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleEventDetails'
+              example:
+                Id: "1"
+                Start: "Du mercredi 5 décembre 2001 à 08:00"
+                End: "Au mercredi 5 décembre 2001 à 10:00"
+                Status: "REALISE"
+                Subject: "Herbology"
+                Type: "Travaux dirigés"
+                Description: ""
+                IsPaper: false
+                Rooms:
+                  - Greenhouse
+                Teachers:
+                  - Sprout Professor
+                Students:
+                  - GRANGER Hermione
+                  - POTTER Harry
+                  - WEASLEY Ronald
+                Groups:
+                  - 0102YEAR1
+                CourseName: "Herbology Class"
+                Module: "Herbology"
+        '401':
+          description: Not authenticated
 
 components:
   schemas:
@@ -203,6 +246,45 @@ components:
         Editable:
           type: boolean
         ClassName:
+          type: string
+    ScheduleEventDetails:
+      type: object
+      properties:
+        Id:
+          type: string
+        Start:
+          type: string
+        End:
+          type: string
+        Status:
+          type: string
+        Subject:
+          type: string
+        Type:
+          type: string
+        Description:
+          type: string
+        IsPaper:
+          type: boolean
+        Rooms:
+          type: array
+          items:
+            type: string
+        Teachers:
+          type: array
+          items:
+            type: string
+        Students:
+          type: array
+          items:
+            type: string
+        Groups:
+          type: array
+          items:
+            type: string
+        CourseName:
+          type: string
+        Module:
           type: string
 
   securitySchemes:

--- a/openapi.yml
+++ b/openapi.yml
@@ -159,26 +159,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/ScheduleEventDetails'
               example:
-                Id: "1"
-                Start: "Du mercredi 5 décembre 2001 à 08:00"
-                End: "Au mercredi 5 décembre 2001 à 10:00"
-                Status: "REALISE"
-                Subject: "Herbology"
-                Type: "Travaux dirigés"
-                Description: ""
-                IsPaper: false
-                Rooms:
+                id: "1"
+                start: "Du mercredi 5 décembre 2001 à 08:00"
+                end: "Au mercredi 5 décembre 2001 à 10:00"
+                status: "REALISE"
+                subject: "Herbology"
+                type: "Travaux dirigés"
+                description: ""
+                isPaper: false
+                rooms:
                   - Greenhouse
-                Teachers:
+                teachers:
                   - Sprout Professor
-                Students:
+                students:
                   - GRANGER Hermione
                   - POTTER Harry
                   - WEASLEY Ronald
-                Groups:
+                groups:
                   - 0102YEAR1
-                CourseName: "Herbology Class"
-                Module: "Herbology"
+                courseName: "Herbology Class"
+                module: "Herbology"
         '401':
           description: Not authenticated
 
@@ -250,41 +250,41 @@ components:
     ScheduleEventDetails:
       type: object
       properties:
-        Id:
+        id:
           type: string
-        Start:
+        start:
           type: string
-        End:
+        end:
           type: string
-        Status:
+        status:
           type: string
-        Subject:
+        subject:
           type: string
-        Type:
+        type:
           type: string
-        Description:
+        description:
           type: string
-        IsPaper:
+        isPaper:
           type: boolean
-        Rooms:
+        rooms:
           type: array
           items:
             type: string
-        Teachers:
+        teachers:
           type: array
           items:
             type: string
-        Students:
+        students:
           type: array
           items:
             type: string
-        Groups:
+        groups:
           type: array
           items:
             type: string
-        CourseName:
+        courseName:
           type: string
-        Module:
+        module:
           type: string
 
   securitySchemes:

--- a/openapi.yml
+++ b/openapi.yml
@@ -103,9 +103,39 @@ paths:
     get:
       security:
         - BearerAuth: []
+      parameters:
+        - in: query
+          name: start
+          schema:
+            type: integer
+          description: The start timestamp in UNIX Milliseconds when the events in the agenda will begin
+        - in: query
+          name: end
+          schema:
+            type: integer
+          description: The end timestamp in UNIX Milliseconds when the events in the agenda will end
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScheduleEvent'
+              example:
+                - Id: "1"
+                  Title: "08:00 - 10:00 - Herbology Class - Professor - Sprout - GreenHouse - TD - (02h00) -  - 154632"
+                  Start: "2001-12-05T08:00:00+0100"
+                  End: "2001-12-05T10:00:00+0100"
+                  Editable: true
+                  ClassName: "TD"
+                - Id: "2"
+                  Title: "10:00 - 12:00 - Potion Class - Severus - Snape - Alchemy Classroom - Magistral Course - (02h00) -  - 597864"
+                  Start: "2001-12-05T10:00:00+0100"
+                  End: "2001-12-05T12:00:00+0100"
+                  Editable: true
+                  ClassName: "CM"
         '401':
           description: Not authenticated
 
@@ -157,6 +187,23 @@ components:
           type: array
           items:
             type: string
+    ScheduleEvent:
+      type: object
+      properties:
+        Id:
+          type: string
+        Title:
+          type: string
+        Start:
+          type: string
+        End:
+          type: string
+        AllDay:
+          type: boolean
+        Editable:
+          type: boolean
+        ClassName:
+          type: string
 
   securitySchemes:
    BearerAuth:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -30,7 +30,33 @@ func AbsencesGet(c *gin.Context) {
 
 // AgendaGet -
 func AgendaGet(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{})
+	token := c.GetHeader("Token")
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing token header"})
+		return
+	}
+
+	if token == "FAKETOKEN" {
+		c.JSON(http.StatusOK, "TODO")
+		return
+	}
+
+	queryParams := c.Request.URL.Query()
+	scheduleOptions := aurion.ScrapScheduleOption{
+		Start:    queryParams.Get("start"),
+		End:      queryParams.Get("end"),
+		View:     queryParams.Get("view"),
+		Date:     queryParams.Get("date"),
+		Week:     queryParams.Get("week"),
+		Location: queryParams.Get("location"),
+	}
+
+	agenda, err := isen.GetPersonalAgenda(aurion.Token(token), scheduleOptions)
+	if err != nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, agenda)
 }
 
 // NotationsGet - Returns a list of all user's notes

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -64,11 +64,17 @@ func EventAgendaGet(c *gin.Context) {
 		return
 	}
 
+	eventId := c.Param("eventId")
+
 	if token == "FAKETOKEN" {
-		c.JSON(http.StatusOK, "TODO")
+		if eventId == "1" {
+			c.JSON(http.StatusOK, fakeEvent)
+		} else {
+			c.JSON(http.StatusOK, "{}")
+		}
+
 		return
 	}
-	eventId := c.Param("eventId")
 
 	event, err := isen.GetPersonalAgendaEvent(aurion.Token(token), aurion.EventId(eventId))
 	if err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -28,7 +28,8 @@ func AbsencesGet(c *gin.Context) {
 	c.JSON(http.StatusOK, absences)
 }
 
-// AgendaGet -
+// AgendaGet - Returns a list of all user's courses between start and end timestamps.
+// start and end must be milliseconds UNIX timestamps. They are not mandatory and have defaults to the first and last day of the week.
 func AgendaGet(c *gin.Context) {
 	token := c.GetHeader("Token")
 	if token == "" {
@@ -37,7 +38,7 @@ func AgendaGet(c *gin.Context) {
 	}
 
 	if token == "FAKETOKEN" {
-		c.JSON(http.StatusOK, "TODO")
+		c.JSON(http.StatusOK, fakeAgenda)
 		return
 	}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -43,12 +43,8 @@ func AgendaGet(c *gin.Context) {
 
 	queryParams := c.Request.URL.Query()
 	scheduleOptions := aurion.ScrapScheduleOption{
-		Start:    queryParams.Get("start"),
-		End:      queryParams.Get("end"),
-		View:     queryParams.Get("view"),
-		Date:     queryParams.Get("date"),
-		Week:     queryParams.Get("week"),
-		Location: queryParams.Get("location"),
+		Start: queryParams.Get("start"),
+		End:   queryParams.Get("end"),
 	}
 
 	agenda, err := isen.GetPersonalAgenda(aurion.Token(token), scheduleOptions)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -56,6 +56,28 @@ func AgendaGet(c *gin.Context) {
 	c.JSON(http.StatusOK, agenda)
 }
 
+// EventAgendaGet -
+func EventAgendaGet(c *gin.Context) {
+	token := c.GetHeader("Token")
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing token header"})
+		return
+	}
+
+	if token == "FAKETOKEN" {
+		c.JSON(http.StatusOK, "TODO")
+		return
+	}
+	eventId := c.Param("eventId")
+
+	event, err := isen.GetPersonalAgendaEvent(aurion.Token(token), aurion.EventId(eventId))
+	if err != nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, event)
+}
+
 // NotationsGet - Returns a list of all user's notes
 func NotationsGet(c *gin.Context) {
 	token := c.GetHeader("Token")

--- a/pkg/api/fake.go
+++ b/pkg/api/fake.go
@@ -58,3 +58,20 @@ var fakeAgenda = []isen.ScheduleEvent{
 		ClassName: "CM",
 	},
 }
+
+var fakeEvent = isen.ScheduleEventDetails{
+	Id:          "1",
+	Start:       "Du mercredi 5 décembre 2001 à 08:00",
+	End:         "Au mercredi 5 décembre 2001 à 10:00",
+	Status:      "REALISE",
+	Subject:     "Herbology",
+	Type:        "Travaux dirigés",
+	Description: "",
+	IsPaper:     func() *bool { b := false; return &b }(),
+	Rooms:       []string{"Greenhouse"},
+	Teachers:    []string{"Sprout Professor"},
+	Students:    []string{"GRANGER Hermione", "POTTER Harry", "WEASLEY Ronald"},
+	Groups:      []string{"0102YEAR1"},
+	CourseName:  "Herbology Class",
+	Module:      "Herbology",
+}

--- a/pkg/api/fake.go
+++ b/pkg/api/fake.go
@@ -39,3 +39,22 @@ var fakeNotes = []isen.Notation{
 		Teachers: []string{"Quirinus Quirrell", "Dolores Umbridge", "Remus Lupin"},
 	},
 }
+
+var fakeAgenda = []isen.ScheduleEvent{
+	{
+		Id:        "1",
+		Title:     "08:00 - 10:00 - Herbology Class - Professor - Sprout - GreenHouse - TD - (02h00) -  - 154632",
+		Start:     "2001-12-05T08:00:00+0100",
+		End:       "2001-12-05T10:00:00+0100",
+		Editable:  true,
+		ClassName: "TD",
+	},
+	{
+		Id:        "2",
+		Title:     "10:00 - 12:00 - Potion Class - Severus - Snape - Alchemy Classroom - Magistral Course - (02h00) -  - 597864",
+		Start:     "2001-12-05T10:00:00+0100",
+		End:       "2001-12-05T12:00:00+0100",
+		Editable:  true,
+		ClassName: "CM",
+	},
+}

--- a/pkg/api/routers.go
+++ b/pkg/api/routers.go
@@ -73,6 +73,13 @@ var routes = Routes{
 	},
 
 	{
+		"AgendaEventGet",
+		http.MethodGet,
+		"/v1/agenda/event/:eventId",
+		EventAgendaGet,
+	},
+
+	{
 		"NotationsGet",
 		http.MethodGet,
 		"/v1/notations",

--- a/pkg/aurion/schedule.go
+++ b/pkg/aurion/schedule.go
@@ -1,0 +1,174 @@
+package aurion
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"github.com/PuerkitoBio/goquery"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type FormId string
+
+type ScrapScheduleOption struct {
+	Start string
+	End   string
+	// Can be month, agendaWeek or agendaDay
+	View     string
+	Date     string
+	Week     string
+	Location string
+}
+
+func getFormId(document io.Reader) (FormId, error) {
+	doc, err := goquery.NewDocumentFromReader(document)
+	if err != nil {
+		return "", err
+	}
+	formId := doc.Find("div[class=schedule]").First().AttrOr("id", "")
+	return FormId(formId), nil
+}
+
+func CalendarPageOption(scheduleOptions ScrapScheduleOption) ScrapScheduleOption {
+	var now time.Time
+	var start time.Time
+	var end time.Time
+	var week int
+
+	localLoc, _ := time.LoadLocation("Europe/Paris")
+	if scheduleOptions.Date == "" {
+		now = time.Now().In(localLoc)
+	} else {
+		now, _ = time.Parse("02/01/2006", scheduleOptions.Date)
+	}
+
+	if scheduleOptions.Week == "" {
+		week = now.YearDay()/7 + 1
+		if now.Weekday() == time.Sunday {
+			week = week + 1
+		}
+		scheduleOptions.Week = fmt.Sprintf("%02d-%04d", week, now.Year())
+	}
+	fmt.Println(scheduleOptions.Week)
+
+	if scheduleOptions.View == "" {
+		scheduleOptions.View = "agendaWeek"
+	}
+	switch scheduleOptions.View {
+	case "agendaWeek":
+		if now.Weekday() == time.Sunday {
+			start = time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, localLoc)
+			end = time.Date(now.Year(), now.Month(), now.Day()+7, 0, 0, 0, 0, localLoc)
+		} else {
+			start = time.Date(now.Year(), now.Month(), now.Day()-(int(now.Weekday())-1), 0, 0, 0, 0, localLoc)
+			end = time.Date(now.Year(), now.Month(), now.Day()+(7-int(now.Weekday())), 0, 0, 0, 0, localLoc)
+		}
+	case "agendaDay":
+		if now.Weekday() == time.Sunday {
+			start = time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, localLoc)
+			end = time.Date(now.Year(), now.Month(), now.Day()+1, 23, 59, 59, 0, localLoc)
+		} else {
+			start = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, localLoc)
+			end = time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, localLoc)
+		}
+	}
+	//TODO: month view
+
+	return ScrapScheduleOption{
+		Start:    strconv.FormatInt(start.UnixMilli(), 10),
+		End:      strconv.FormatInt(end.UnixMilli(), 10),
+		View:     scheduleOptions.View,
+		Date:     scheduleOptions.Date,
+		Week:     scheduleOptions.Week,
+		Location: scheduleOptions.Location,
+	}
+}
+
+func CalendarPage(formId FormId, options ScrapScheduleOption) ScrapTableOption {
+
+	return ScrapTableOption{
+		Url: "https://ent-toulon.isen.fr/faces/Planning.xhtml",
+		FormOption: url.Values{
+			"javax.faces.partial.ajax":    {"true"},
+			"javax.faces.source":          {string(formId)},
+			"javax.faces.partial.execute": {string(formId)},
+			"javax.faces.partial.render":  {string(formId)},
+			"form":                        {"form"},
+			string(formId):                {string(formId)},
+
+			string(formId + "_start"): {options.Start},
+			string(formId + "_end"):   {options.End},
+			string(formId + "_view"):  {options.View},
+
+			"form:date_input": {options.Date},
+			"form:week":       {options.Week},
+		},
+	}
+}
+
+func ScrapSchedule(token Token, scheduleOptions ScrapScheduleOption, currentPage []byte) (string, error) {
+
+	// Set client
+	client := &http.Client{}
+
+	// Get view state from currentPage
+	reader := bytes.NewReader(currentPage)
+	viewState, err := getViewState(reader)
+	if err != nil {
+		return "", err
+	}
+	// Get form id from currentPage
+	reader = bytes.NewReader(currentPage)
+	formId, err := getFormId(reader)
+	if err != nil {
+		return "", err
+	}
+
+	pageOptions := CalendarPage(formId, CalendarPageOption(scheduleOptions))
+
+	formData := pageOptions.FormOption
+	formData.Add("javax.faces.ViewState", string(viewState))
+
+	req, err := http.NewRequest("POST", pageOptions.Url, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Faces-Request", "partial/ajax")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Cookie", fmt.Sprintf("JSESSIONID=%v", token))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	// Convert partial response to HTML compatible array
+	var partialResponse PartialResponse
+	xml.Unmarshal(content, &partialResponse)
+
+	return convertPartialResponseToJson(partialResponse, formId), nil
+}
+
+func convertPartialResponseToJson(partialResponse PartialResponse, formId FormId) string {
+	var json string
+
+	for _, update := range partialResponse.Changes.Update {
+		if update.ID == string(formId) {
+			// Convert string data to parsable json data
+			json = update.Text[len("{\"events\" : ") : len(update.Text)-1]
+		}
+	}
+	return json
+}

--- a/pkg/aurion/table.go
+++ b/pkg/aurion/table.go
@@ -73,8 +73,11 @@ func convertPartialResponseToHTML(partialResponse PartialResponse) string {
 	var html string
 
 	for _, update := range partialResponse.Changes.Update {
-		if update.ID == "form:dataTableFavori" {
+		switch update.ID {
+		case "form:dataTableFavori":
 			html = fmt.Sprintf("<html><table>%s</table></html>", update.Text)
+		case "form:modaleDetail":
+			html = fmt.Sprintf("<html>%s</html>", update.Text)
 		}
 	}
 	return html

--- a/pkg/isen/const.go
+++ b/pkg/isen/const.go
@@ -10,9 +10,10 @@ const (
 	LoginPage    = "https://ent-toulon.isen.fr/login"
 	MainMenuPage = "https://ent-toulon.isen.fr/faces/MainMenuPage.xhtml"
 
-	SelfInfoMenuId aurion.MenuId = "0_0"
-	NotationMenuId aurion.MenuId = "2_1"
-	AbsenceMenuId  aurion.MenuId = "2_2"
+	SelfInfoMenuId   aurion.MenuId = "0_0"
+	SelfAgendaMenuId aurion.MenuId = "1_0"
+	NotationMenuId   aurion.MenuId = "2_1"
+	AbsenceMenuId    aurion.MenuId = "2_2"
 )
 
 func NotationPage() aurion.ScrapTableOption {

--- a/pkg/isen/planning.go
+++ b/pkg/isen/planning.go
@@ -1,1 +1,40 @@
 package isen
+
+import (
+	"encoding/json"
+	"github.com/AYDEV-FR/ISEN-Api/pkg/aurion"
+)
+
+type ScheduleEvent struct {
+	Id        string `json:"Id,omitempty"`
+	Title     string `json:"Title,omitempty"`
+	Start     string `json:"Start,omitempty"`
+	End       string `json:"End,omitempty"`
+	AllDay    bool   `json:"AllDay,omitempty"`
+	Editable  bool   `json:"Editable,omitempty"`
+	ClassName string `json:"ClassName,omitempty"`
+}
+
+type ScheduleEventDetails struct {
+	Id string `json:"Id,omitempty"`
+}
+
+func GetPersonalAgenda(token aurion.Token, scheduleOptions aurion.ScrapScheduleOption) ([]ScheduleEvent, error) {
+	var planning []ScheduleEvent
+	page, err := aurion.MenuNavigateTo(token, SelfAgendaMenuId, MainMenuPage)
+	if err != nil {
+		return nil, err
+	}
+
+	scheduleEventsJson, err := aurion.ScrapSchedule(token, scheduleOptions, page)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal([]byte(scheduleEventsJson), &planning)
+	if err != nil {
+		return nil, err
+	}
+
+	return planning, err
+}

--- a/pkg/isen/planning.go
+++ b/pkg/isen/planning.go
@@ -18,20 +18,20 @@ type ScheduleEvent struct {
 }
 
 type ScheduleEventDetails struct {
-	Id          aurion.EventId `json:"Id,omitempty"`
-	Start       string         `json:"Start,omitempty"`
-	End         string         `json:"End,omitempty"`
-	Status      string         `json:"Status,omitempty"`
-	Subject     string         `json:"Subject,omitempty"`
-	Type        string         `json:"Type,omitempty"`
-	Description string         `json:"Description,omitempty"`
-	IsPaper     *bool          `json:"IsPaper,omitempty"`
-	Rooms       []string       `json:"Rooms,omitempty"`
-	Teachers    []string       `json:"Teachers,omitempty"`
-	Students    []string       `json:"Students,omitempty"`
-	Groups      []string       `json:"Groups,omitempty"`
-	CourseName  string         `json:"CourseName,omitempty"`
-	Module      string         `json:"Module,omitempty"`
+	Id          aurion.EventId `json:"id,omitempty"`
+	Start       string         `json:"start,omitempty"`
+	End         string         `json:"end,omitempty"`
+	Status      string         `json:"status,omitempty"`
+	Subject     string         `json:"subject,omitempty"`
+	Type        string         `json:"type,omitempty"`
+	Description string         `json:"description,omitempty"`
+	IsPaper     *bool          `json:"isPaper,omitempty"`
+	Rooms       []string       `json:"rooms,omitempty"`
+	Teachers    []string       `json:"teachers,omitempty"`
+	Students    []string       `json:"students,omitempty"`
+	Groups      []string       `json:"groups,omitempty"`
+	CourseName  string         `json:"courseName,omitempty"`
+	Module      string         `json:"module,omitempty"`
 }
 
 func GetPersonalAgenda(token aurion.Token, scheduleOptions aurion.ScrapScheduleOption) ([]ScheduleEvent, error) {


### PR DESCRIPTION
**IMPORTANT** : Ajout à push APRÈS l'ajout du planning ( #5 ) puisqu'il repose sur le même fichier.

Ajout du détails des événements du planning et mise en fonctionnement de l'endpoint `/v1/agenda/event/{eventId}`.
La documentation a été faite dans openapi et un fakeEvent a été créé pour pouvoir tester l'endpoint avec FAKETOKEN.

L'endpoint possède un argument dans le path : `eventId` qui représente l'ID de l'event, trouvable lors d'un appel à l'endpoint `/v1/agenda`
Si un event n'est pas trouvé, le programme renvoie un JSON vide.