### PR TITLE
Continuous Integration : Go linter and security checker

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,55 @@
+name: golandci-lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+env:
+  GO_VERSION: '1.20'
+  GOLANGCI_LINT_VERSION: latest
+
+permissions:
+  # Required: allow read access to the content for analysis.
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+  # Optional: allow write access to checks to allow the action to annotate code in the PR.
+  checks: write
+
+jobs:
+  detect-modules:
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.set-modules.outputs.modules }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Set modules
+        id: set-modules
+        run: echo "modules=$(go list -m -json | jq -s '.' | jq -c '[.[].Dir]')" >> $GITHUB_OUTPUT
+
+  golandci-lint:
+    needs: detect-modules
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        modules: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: golangci-lint ${{ matrix.modules }}
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: ${{ matrix.modules }}
+          only-new-issues: true

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -16,3 +16,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Gosec Security Scanner
         uses: securego/gosec@master
+        with:
+          args: ./...

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,18 @@
+name: Gosec
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  sectest:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Gosec Security Scanner
+        uses: securego/gosec@master

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,8 +1,8 @@
 name: Gosec
 
 on:
-  push:
   pull_request:
+  push:
     branches:
       - main
 


### PR DESCRIPTION
This PR adds a go linter (golangci-lint) and a go security checker (gosec))

One of them fails because some errors are not handled in the code (see output of gosec)

The linter should have seen the problem but did not, why ?
In fact, I used the linter to check only the latest changes, which means it only analyzes the diff committed (see [this link](https://github.com/marketplace/actions/golangci-lint#only-new-issues) for more info)

So, do we keep it like this or do I set it to the whole package ?
And do we fix the issues making gosec unhappy in this PR or do we make another one ?