### PR TITLE
http requests now have a timeout of 10 seconds

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -22,7 +22,7 @@ func AbsencesGet(c *gin.Context) {
 
 	absences, err := isen.GetAbsenceList(aurion.Token(token))
 	if err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, absences)
@@ -50,7 +50,7 @@ func AgendaGet(c *gin.Context) {
 
 	agenda, err := isen.GetPersonalAgenda(aurion.Token(token), scheduleOptions)
 	if err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, agenda)
@@ -78,7 +78,7 @@ func EventAgendaGet(c *gin.Context) {
 
 	event, err := isen.GetPersonalAgendaEvent(aurion.Token(token), aurion.EventId(eventId))
 	if err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, event)
@@ -99,11 +99,12 @@ func NotationsGet(c *gin.Context) {
 
 	notation, err := isen.GetNotationList(aurion.Token(token))
 	if err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, notation)
 }
+
 // NotationsClassGet - Returns a list of all user's class notes with min, average and max note
 func NotationsClassGet(c *gin.Context) {
 	token := c.GetHeader("Token")
@@ -119,7 +120,7 @@ func NotationsClassGet(c *gin.Context) {
 
 	notationClass, err := isen.GetNotationClassList(aurion.Token(token))
 	if err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, notationClass)
@@ -127,25 +128,25 @@ func NotationsClassGet(c *gin.Context) {
 
 // PersonalInformationsGet - Returns user's personal informations
 func PersonalInformationsGet(c *gin.Context) {
-  token := c.GetHeader("Token")
+	token := c.GetHeader("Token")
 	if token == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "missing token header"})
 		return
 	}
 
 	if token == "FAKETOKEN" {
-    c.JSON(http.StatusOK, fakePersonalInformations)
+		c.JSON(http.StatusOK, fakePersonalInformations)
 		return
 	}
 
 	infos, err := isen.GetPersonalInformations(aurion.Token(token))
-  
-  if err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-  
-  c.JSON(http.StatusOK, infos)
+
+	c.JSON(http.StatusOK, infos)
 }
 
 // TokenPost -
@@ -164,7 +165,7 @@ func TokenPost(c *gin.Context) {
 
 	token, err := aurion.GetToken(loginCredentials.Username, loginCredentials.Password, isen.LoginPage)
 	if err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.Data(http.StatusOK, "text/plain", []byte(token))

--- a/pkg/aurion/login.go
+++ b/pkg/aurion/login.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type Token string
@@ -24,6 +25,7 @@ func GetToken(username string, password string, loginPage string) (Token, error)
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
+		Timeout: 10 * time.Second,
 	}
 	req, err := http.NewRequest("POST", loginPage, strings.NewReader(data.Encode()))
 	if err != nil {

--- a/pkg/aurion/navigate.go
+++ b/pkg/aurion/navigate.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type MenuId []string
@@ -15,7 +16,9 @@ type MenuId []string
 // MenuNavigateTo
 func MenuNavigateTo(token Token, menuId MenuId, mainMenuUrl string) ([]byte, error) {
 	// Set client
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
 
 	// Get homepage
 	req, err := http.NewRequest("GET", mainMenuUrl, nil)

--- a/pkg/aurion/schedule.go
+++ b/pkg/aurion/schedule.go
@@ -99,7 +99,9 @@ func CalendarEventPage(formId FormId, eventId EventId) ScrapTableOption {
 func ScrapSchedule(token Token, scheduleOptions ScrapScheduleOption, currentPage []byte) (string, error) {
 
 	// Set client
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
 
 	// Get view state from currentPage
 	reader := bytes.NewReader(currentPage)
@@ -149,7 +151,9 @@ func ScrapSchedule(token Token, scheduleOptions ScrapScheduleOption, currentPage
 }
 
 func ScrapScheduleEvent(token Token, eventId EventId, currentPage []byte) (string, error) {
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
 
 	// Get view state from currentPage
 	reader := bytes.NewReader(currentPage)

--- a/pkg/aurion/sidebarid.go
+++ b/pkg/aurion/sidebarid.go
@@ -8,13 +8,16 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type SidebarId string
 type WebscolaappId string
 
 func updateSidebarSubmenu(token Token, viewState ViewState, wId WebscolaappId, mainMenuUrl string) (string, ViewState, error) {
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
 
 	// prepare form values to load every child of a submenu.
 	// j_idt52 is a const that doesn't change

--- a/pkg/aurion/table.go
+++ b/pkg/aurion/table.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type PartialResponse struct {
@@ -31,7 +32,9 @@ type ScrapTableOption struct {
 func ScrapTable(token Token, currentPage []byte, pageOptions ScrapTableOption) (string, error) {
 
 	// Set client
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
 
 	// Get view state from currentPage
 	reader := bytes.NewReader(currentPage)


### PR DESCRIPTION
As a request takes approximately between 500ms and 1s, this PR sets a timeout of 10 seconds for every requests, avoiding infinite call loop if ISEN server is down as stated in #15.

This PR also changes previous code error sent if server had an error during scraping, it was sending a 403 Forbidden code, now replaced by a 500 Internal Server Error code.