### PR TITLE
HTTP codes are now correct for some specific errors

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -55,6 +55,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
                     }
                 }
             }
@@ -106,6 +112,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
                     }
                 }
             }
@@ -149,6 +161,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
                     }
                 }
             }
@@ -183,6 +201,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
@@ -223,6 +247,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
                     }
                 }
             }
@@ -254,6 +284,12 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
@@ -295,8 +331,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.HTTPError"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -48,6 +48,12 @@
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
                     }
                 }
             }
@@ -99,6 +105,12 @@
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
                     }
                 }
             }
@@ -142,6 +154,12 @@
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
                     }
                 }
             }
@@ -176,6 +194,12 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
@@ -216,6 +240,12 @@
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
                     }
                 }
             }
@@ -247,6 +277,12 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }
@@ -288,8 +324,20 @@
                             "$ref": "#/definitions/api.HTTPError"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.HTTPError"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
                         "schema": {
                             "$ref": "#/definitions/api.HTTPError"
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -400,6 +400,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.HTTPError'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/api.HTTPError'
       security:
       - ApiKeyAuth: []
       summary: List user's absences
@@ -432,6 +436,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.HTTPError'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/api.HTTPError'
       security:
       - ApiKeyAuth: []
       summary: Get user's agenda
@@ -459,6 +467,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.HTTPError'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/api.HTTPError'
       security:
       - ApiKeyAuth: []
       summary: Get informations from a specific event
@@ -480,6 +492,10 @@ paths:
             $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.HTTPError'
+        "504":
+          description: Gateway Timeout
           schema:
             $ref: '#/definitions/api.HTTPError'
       security:
@@ -506,6 +522,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.HTTPError'
+        "504":
+          description: Gateway Timeout
+          schema:
+            $ref: '#/definitions/api.HTTPError'
       security:
       - ApiKeyAuth: []
       summary: List user's class notations
@@ -525,6 +545,10 @@ paths:
             $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.HTTPError'
+        "504":
+          description: Gateway Timeout
           schema:
             $ref: '#/definitions/api.HTTPError'
       security:
@@ -553,8 +577,16 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/api.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.HTTPError'
         "500":
           description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.HTTPError'
+        "504":
+          description: Gateway Timeout
           schema:
             $ref: '#/definitions/api.HTTPError'
       summary: Get ISEN Token

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/AYDEV-FR/ISEN-Api/pkg/aurion"
 	"github.com/AYDEV-FR/ISEN-Api/pkg/isen"
@@ -20,6 +21,7 @@ type HTTPError struct {
 //	@Success		200	{array}		isen.Absence
 //	@Failure		400	{object}	HTTPError
 //	@Failure		500	{object}	HTTPError
+//	@Failure		504	{object}	HTTPError
 //	@Security		ApiKeyAuth
 //	@Router			/absences [get]
 func AbsencesGet(c *gin.Context) {
@@ -35,6 +37,10 @@ func AbsencesGet(c *gin.Context) {
 
 	absences, err := isen.GetAbsenceList(aurion.Token(token))
 	if err != nil {
+		if os.IsTimeout(err) {
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -51,6 +57,7 @@ func AbsencesGet(c *gin.Context) {
 //	@Success		200		{array}		isen.ScheduleEvent
 //	@Failure		400		{object}	HTTPError
 //	@Failure		500		{object}	HTTPError
+//	@Failure		504		{object}	HTTPError
 //	@Security		ApiKeyAuth
 //	@Router			/agenda [get]
 func AgendaGet(c *gin.Context) {
@@ -73,6 +80,10 @@ func AgendaGet(c *gin.Context) {
 
 	agenda, err := isen.GetPersonalAgenda(aurion.Token(token), scheduleOptions)
 	if err != nil {
+		if os.IsTimeout(err) {
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -88,6 +99,7 @@ func AgendaGet(c *gin.Context) {
 //	@Success		200		{object}	isen.ScheduleEventDetails
 //	@Failure		400		{object}	HTTPError
 //	@Failure		500		{object}	HTTPError
+//	@Failure		504		{object}	HTTPError
 //	@Security		ApiKeyAuth
 //	@Router			/agenda/event/{eventId} [get]
 func EventAgendaGet(c *gin.Context) {
@@ -111,6 +123,10 @@ func EventAgendaGet(c *gin.Context) {
 
 	event, err := isen.GetPersonalAgendaEvent(aurion.Token(token), aurion.EventId(eventId))
 	if err != nil {
+		if os.IsTimeout(err) {
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -125,6 +141,7 @@ func EventAgendaGet(c *gin.Context) {
 //	@Success		200	{array}		isen.Notation
 //	@Failure		400	{object}	HTTPError
 //	@Failure		500	{object}	HTTPError
+//	@Failure		504	{object}	HTTPError
 //	@Security		ApiKeyAuth
 //	@Router			/notations [get]
 func NotationsGet(c *gin.Context) {
@@ -141,6 +158,10 @@ func NotationsGet(c *gin.Context) {
 
 	notation, err := isen.GetNotationList(aurion.Token(token))
 	if err != nil {
+		if os.IsTimeout(err) {
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -155,6 +176,7 @@ func NotationsGet(c *gin.Context) {
 //	@Success		200	{array}		isen.Notation
 //	@Failure		400	{object}	HTTPError
 //	@Failure		500	{object}	HTTPError
+//	@Failure		504	{object}	HTTPError
 //	@Security		ApiKeyAuth
 //	@Router			/notations/class [get]
 func NotationsClassGet(c *gin.Context) {
@@ -171,6 +193,10 @@ func NotationsClassGet(c *gin.Context) {
 
 	notationClass, err := isen.GetNotationClassList(aurion.Token(token))
 	if err != nil {
+		if os.IsTimeout(err) {
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -185,6 +211,7 @@ func NotationsClassGet(c *gin.Context) {
 //	@Success		200	{object}	isen.PersonalInformations
 //	@Failure		400	{object}	HTTPError
 //	@Failure		500	{object}	HTTPError
+//	@Failure		504	{object}	HTTPError
 //	@Security		ApiKeyAuth
 //	@Router			/personal-informations [get]
 func PersonalInformationsGet(c *gin.Context) {
@@ -202,6 +229,10 @@ func PersonalInformationsGet(c *gin.Context) {
 	infos, err := isen.GetPersonalInformations(aurion.Token(token))
 
 	if err != nil {
+		if os.IsTimeout(err) {
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -218,7 +249,9 @@ func PersonalInformationsGet(c *gin.Context) {
 //	@Param			account	body		aurion.Login	true	"Account credentials"
 //	@Success		200		{string}	string
 //	@Failure		400		{object}	HTTPError
+//	@Failure		401		{object}	HTTPError
 //	@Failure		500		{object}	HTTPError
+//	@Failure		504		{object}	HTTPError
 //	@Router			/token [post]
 func TokenPost(c *gin.Context) {
 	var loginCredentials aurion.Login
@@ -235,6 +268,13 @@ func TokenPost(c *gin.Context) {
 
 	token, err := aurion.GetToken(loginCredentials.Username, loginCredentials.Password, isen.LoginPage)
 	if err != nil {
+		if err.Error() == "login ou mot de passe invalide" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+			return
+		} else if os.IsTimeout(err) {
+			c.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}


### PR DESCRIPTION
## Type of change
<!--
Check the boxes that fits best what this PR is for
To check a box in Markdown, you need to put an x in the box.
Example :
- [x] checked
- [ ] unchecked
-->
- [x] Bugfix (fixes an issue)
- [ ] New feature (adds a new feature to the project)
- [ ] Breaking change (can make one or more existing functionality to not work properly)
- [ ] Documentation
- [ ] Other (please describe)

## Proposed changes
<!--
Describe clearly and concisely what this PR changes or adds
If this PR is related to an existing issue, please mention it in this section
-->
This PR fixes #27
Some specific errors were not returning correct HTTP codes as described in the issue.
This PR corrects this, by making the API send a 504 Gateway Timeout when the http client triggers a timeout and a 401 Unauthorized when the end user enters wrong credentials.

## Further comments
<!--
Optional
Add useful context, or how you did resolve the issue if the fix is complex
-->
This has been tested by changing http timeout in `navigate.go` file from 10 seconds to 1 millisecond for the 504 Bad Gateway, and with sending invented credentials on `/token` endpoint.